### PR TITLE
docs: Update README and add SlipStack usage GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Returned when you attach `ref` to the container.
 | Method     | Description                                       |
 |------------|---------------------------------------------------|
 | `openPane` | `openPane(next: SlipStackPaneData): void` &nbsp;—&nbsp;programmatically open or navigate to *next*. |
+| `closePane` | `closePane(id: string): void` &nbsp;—&nbsp;programmatically close a specified pane by its identifier. |
 
 Calling `openPane(next)` appends *next* to the right of the calling pane and removes any panes that were further right.
 
@@ -105,9 +106,8 @@ Calling `openPane(next)` appends *next* to the right of the calling pane and rem
 • If the total width of visible panes exceeds the viewport, the container
   converts the left-most panes into 40 px vertical tabs and/or horizontally
   scrolls the sliding track to keep everything accessible.  
-• `openPane(next)` appends (or navigates to) *next*, recomputes the layout,
-  and scrolls the new pane into view. The same `openPane` reference is passed
-  to every `SlipStackPaneRenderer`.
+• `openPane(next)` appends (or navigates to) *next*, recomputes the layout, and scrolls the new pane into view.  
+• `closePane(id)` removes the pane with the specified `id` from the container and recomputes the layout.
 
 ## Contributing
 PRs and issues are welcome. Run the dev setup with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SlipStack
 Beautiful, sliding, stacking panes for React.
 
+![SlipStack in action](slipstack-react.gif)
+
 ## Installation
 ```bash
 npm i slipstack-react

--- a/README.md
+++ b/README.md
@@ -82,13 +82,6 @@ interface SlipStackPaneData {
 }
 ```
 
-### `SlipStackPaneRenderer`
-```ts
-type SlipStackPaneRenderer = (args: {
-  openPane: (next: SlipStackPaneData) => void;
-}) => ReactNode;
-```
-
 ### SlipStackHandle
 Returned when you attach `ref` to the container.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ npm dev
 |-------------|-----------------------|---------|----------------------------------------|
 | `paneData`  | `SlipStackPaneData[]` | –       | Panes shown when the component mounts. |
 | `paneWidth` | `number`              | `380`   | Maximum width of each pane.            |
+| `tabWidth`  | `number`              | `40`    | Maximum width of each tab.             |
 
 ### `SlipStackPaneData`
 


### PR DESCRIPTION
This pull request includes updates to the project's documentation and assets:
- Removed the `SlipStackPaneRenderer` section from `README.md`.
- Added details about the `closePane` method and updated behavior notes in `README.md`.
- Documented the new `tabWidth` property in the `Container` API within `README.md`.
- Included a GIF demonstrating `SlipStack` usage in `README.md`.
- Added the `slipstack-react.gif` file to the repository.